### PR TITLE
Update Runtime to 6.6

### DIFF
--- a/com.github.Rosalie241.RMG.yml
+++ b/com.github.Rosalie241.RMG.yml
@@ -1,6 +1,6 @@
 app-id: com.github.Rosalie241.RMG
 runtime: org.kde.Platform
-runtime-version: 6.5
+runtime-version: 6.6
 sdk: org.kde.Sdk
 command: RMG
 finish-args:


### PR DESCRIPTION
The new SDK now contains GCC 13